### PR TITLE
Add default policy and imeout to override the "hard coded" value consumerBuilder

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/AmqpProvider.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/AmqpProvider.java
@@ -57,6 +57,9 @@ import org.apache.qpid.jms.provider.amqp.builders.AmqpConnectionBuilder;
 import org.apache.qpid.jms.transports.TransportFactory;
 import org.apache.qpid.jms.transports.TransportListener;
 import org.apache.qpid.jms.util.IOExceptionSupport;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.UnsignedInteger;
+import org.apache.qpid.proton.amqp.messaging.TerminusExpiryPolicy;
 import org.apache.qpid.proton.engine.Collector;
 import org.apache.qpid.proton.engine.Connection;
 import org.apache.qpid.proton.engine.EndpointState;
@@ -117,6 +120,8 @@ public class AmqpProvider implements Provider, TransportListener , AmqpResourceP
     private int drainTimeout = 60000;
     private long sessionOutoingWindow = -1; //Use proton default
     private int maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
+	private TerminusExpiryPolicy defaultExpiryPolicy;
+	private UnsignedInteger defaultTimeout;
 
     private final URI remoteURI;
     private final AtomicBoolean closed = new AtomicBoolean();
@@ -1071,6 +1076,36 @@ public class AmqpProvider implements Provider, TransportListener , AmqpResourceP
         this.sessionOutoingWindow = sessionOutoingWindow;
     }
 
+	public TerminusExpiryPolicy getDefaultExpiryPolicy() {
+		return defaultExpiryPolicy;
+	}
+
+	/**
+     * Set the default expiry policy. This will override consumer policy.
+     * 
+     * @param defaultExpiryPolicy
+     */
+	public void setDefaultExpiryPolicy(String defaultExpiryPolicy) {
+		this.defaultExpiryPolicy = TerminusExpiryPolicy.valueOf(Symbol.valueOf(defaultExpiryPolicy));
+	}
+
+	public UnsignedInteger getDefaultTimeout() {
+		return defaultTimeout;
+	}
+
+	/**
+	 * Set the default timeout for consumer policy
+	 * 
+	 * @param timeout
+	 */
+	public void setDefaultTimeout(int timeout) {
+		if (timeout < 0) {
+			defaultTimeout = new UnsignedInteger(Integer.MAX_VALUE);
+		} else {
+			defaultTimeout = new UnsignedInteger(timeout);
+		}
+	}
+
     public long getCloseTimeout() {
         return this.closeTimeout;
     }
@@ -1178,7 +1213,7 @@ public class AmqpProvider implements Provider, TransportListener , AmqpResourceP
         }
     }
 
-    private final class IdleTimeoutCheck implements Runnable {
+	private final class IdleTimeoutCheck implements Runnable {
         @Override
         public void run() {
             boolean checkScheduled = false;

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/builders/AmqpConsumerBuilder.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/builders/AmqpConsumerBuilder.java
@@ -127,6 +127,13 @@ public class AmqpConsumerBuilder extends AmqpResourceBuilder<AmqpConsumer, AmqpS
             source.setExpiryPolicy(TerminusExpiryPolicy.LINK_DETACH);
         }
 
+		if (this.parent.getConnection().getProvider().getDefaultExpiryPolicy() != null) {
+			source.setExpiryPolicy(this.parent.getConnection().getProvider().getDefaultExpiryPolicy());
+		}
+		if (this.parent.getConnection().getProvider().getDefaultTimeout() != null) {
+			source.setTimeout(this.parent.getConnection().getProvider().getDefaultTimeout());
+		}
+
         if (resourceInfo.isBrowser()) {
             source.setDistributionMode(COPY);
         }


### PR DESCRIPTION
I got an issue with a broker that do not support "NEVER" as expiration policy. (if timeout is set as 0 it will means that consumer is a "temporary consumer" no matter what).
If I try to set a timeout >0 and a expiration policy to NEVER, it crash. 

 I created this hack to fix that. I can add 2 more parameters : 
Example: 
amqp://localhost:5672?amqp.defaultTimeout=2000000&amqp.defaultExpiryPolicy=link-detach 

make this connection a almost a durable connection.