### PR TITLE
QPIDJMS-164: Provide OSGi metadata for qpid-jms-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <maven-javacc-plugin-version>2.6</maven-javacc-plugin-version>
     <maven-eclipse-plugin-version>2.10</maven-eclipse-plugin-version>
     <maven-idea-plugin-version>2.5</maven-idea-plugin-version>
+    <maven-bundle-plugin-version>3.2.0</maven-bundle-plugin-version>
     <findbugs-maven-plugin-version>3.0.2</findbugs-maven-plugin-version>
     <jacoco-plugin-version>0.7.5.201505241946</jacoco-plugin-version>
 
@@ -213,6 +214,12 @@
             <downloadSources>true</downloadSources>
             <downloadJavadocs>true</downloadJavadocs>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>${maven-bundle-plugin-version}</version>
+          <extensions>true</extensions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/qpid-jms-client/pom.xml
+++ b/qpid-jms-client/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <artifactId>qpid-jms-client</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <name>QpidJMS Client</name>
   <description>The core JMS Client implementation</description>
 
@@ -111,6 +111,21 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.apache.qpid.jms.client</Bundle-SymbolicName>
+            <Export-Package>org.apache.qpid.jms.*</Export-Package>
+            <Import-Package>
+            io.netty.*;version="[4.0.0,4.1.0)",
+            org.apache.qpid.proton.*;version="[0.14.0,0.15.0)",
+            *</Import-Package>
+            <Dynamic-ImportPackage>*</Dynamic-ImportPackage>
+          </instructions>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
This change adds the maven-bundle-plugin to the parent project and
activates it in the qpid-jms-client project, generating OSGi meta data
for the project.

The Bundle-SymbolicName is overridden to "org.apache.qpid.jms.client".

The DynamicPackage-Import header is set to "*" since the JMS client can
actually create instances from all kind of classes.

The final MANIFEST.MF no longer contains the following entries though:

```
Implementation-Title: QpidJMS Client
Implementation-Version: 0.20.0-SNAPSHOT
Implementation-Vendor-Id: org.apache.qpid
Implementation-Vendor: The Apache Software Foundation
Specification-Vendor: The Apache Software Foundation
Specification-Title: QpidJMS Client
Specification-Version: 0.20.0-SNAPSHOT
```

Signed-off-by: Jens Reimann <jreimann@redhat.com>