### PR TITLE
Make it possible to choose type of acknowledge for redeliveries [QPIDJMS-274]

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/policy/JmsDefaultRedeliveryPolicy.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/policy/JmsDefaultRedeliveryPolicy.java
@@ -17,6 +17,7 @@
 package org.apache.qpid.jms.policy;
 
 import org.apache.qpid.jms.JmsDestination;
+import org.apache.qpid.jms.provider.ProviderConstants.ACK_TYPE;
 
 /**
  * Defines the policy used to manage redelivered and recovered Messages.
@@ -24,15 +25,19 @@ import org.apache.qpid.jms.JmsDestination;
 public class JmsDefaultRedeliveryPolicy implements JmsRedeliveryPolicy {
 
     public static final int DEFAULT_MAX_REDELIVERIES = -1;
+    public static final ACK_TYPE DEFAULT_ACK_TYPE = ACK_TYPE.MODIFIED_FAILED_UNDELIVERABLE;
 
     private int maxRedeliveries;
+    private ACK_TYPE ackType;
 
     public JmsDefaultRedeliveryPolicy() {
         maxRedeliveries = DEFAULT_MAX_REDELIVERIES;
+        ackType = DEFAULT_ACK_TYPE;
     }
 
     public JmsDefaultRedeliveryPolicy(JmsDefaultRedeliveryPolicy source) {
         maxRedeliveries = source.maxRedeliveries;
+        ackType = source.ackType;
     }
 
     @Override
@@ -43,6 +48,32 @@ public class JmsDefaultRedeliveryPolicy implements JmsRedeliveryPolicy {
     @Override
     public int getMaxRedeliveries(JmsDestination destination) {
         return maxRedeliveries;
+    }
+
+    @Override
+    public ACK_TYPE getAckType(JmsDestination destination) {
+        return ackType;
+    }
+
+    /**
+     * Returns the configured acknowledge type that will be used when rejecting messages.
+     * <p>
+     * Default acknowledgement type is ACK_TYPE.MODIFIED_FAILED_UNDELIVERABLE.
+     *
+     * @return the ackType
+     *         the acknowledge type to use when rejecting messages.
+     */
+    public ACK_TYPE getAckType() {
+        return ackType;
+    }
+
+    /**
+     * Set the acknowledgement type to use when rejecting messages.
+     * 
+     * @param ackType
+     */
+    public void setAckType(ACK_TYPE ackType) {
+        this.ackType = ackType;
     }
 
     /**
@@ -73,6 +104,7 @@ public class JmsDefaultRedeliveryPolicy implements JmsRedeliveryPolicy {
         final int prime = 31;
         int result = 1;
         result = prime * result + maxRedeliveries;
+        result = prime * result + ackType.ordinal();
         return result;
     }
 
@@ -91,10 +123,7 @@ public class JmsDefaultRedeliveryPolicy implements JmsRedeliveryPolicy {
         }
 
         JmsDefaultRedeliveryPolicy other = (JmsDefaultRedeliveryPolicy) obj;
-        if (maxRedeliveries != other.maxRedeliveries) {
-            return false;
-        }
 
-        return true;
+        return maxRedeliveries == other.maxRedeliveries && ackType == other.ackType;
     }
 }

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/policy/JmsRedeliveryPolicy.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/policy/JmsRedeliveryPolicy.java
@@ -17,6 +17,7 @@
 package org.apache.qpid.jms.policy;
 
 import org.apache.qpid.jms.JmsDestination;
+import org.apache.qpid.jms.provider.ProviderConstants.ACK_TYPE;
 
 /**
  * Interface for a Redelivery Policy object used to determine how many times a Message
@@ -41,4 +42,15 @@ public interface JmsRedeliveryPolicy {
      */
     int getMaxRedeliveries(JmsDestination destination);
 
+    /**
+     * Returns the configured acknowledge type that will be used when rejecting the
+     * message by this client for the given destination.
+     *
+     * @param destination
+     *      the destination that the subscription is redelivering from.
+     *
+     * @return the ackType
+     *         the acknowledge type to use when rejecting messages.
+     */
+    ACK_TYPE getAckType(JmsDestination destination);
 }

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/integration/ConnectionFactoryIntegrationTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/integration/ConnectionFactoryIntegrationTest.java
@@ -47,6 +47,7 @@ import org.apache.qpid.jms.policy.JmsMessageIDPolicy;
 import org.apache.qpid.jms.policy.JmsPrefetchPolicy;
 import org.apache.qpid.jms.policy.JmsPresettlePolicy;
 import org.apache.qpid.jms.policy.JmsRedeliveryPolicy;
+import org.apache.qpid.jms.provider.ProviderConstants.ACK_TYPE;
 import org.apache.qpid.jms.test.QpidJmsTestCase;
 import org.apache.qpid.jms.test.testpeer.TestAmqpPeer;
 import org.junit.Test;
@@ -547,6 +548,11 @@ public class ConnectionFactoryIntegrationTest extends QpidJmsTestCase {
         @Override
         public int getMaxRedeliveries(JmsDestination destination) {
             return JmsDefaultRedeliveryPolicy.DEFAULT_MAX_REDELIVERIES;
+        }
+
+        @Override
+        public ACK_TYPE getAckType(JmsDestination destination) {
+            return ACK_TYPE.MODIFIED_FAILED_UNDELIVERABLE;
         }
     }
 }


### PR DESCRIPTION
This is left here as a base for discussion. I want to be able to choose the acknowledge type for messages rejected by a custom JmsRedeliveryPolicy. I added a request to Jira: QPIDJMS-274, https://issues.apache.org/jira/browse/QPIDJMS-274

The particular use case is that I want to be able to do explicit dead lettering with Azure Service Bus in a Camel route where I do redeliveries in Camel, and if failing explicitely dead letter the messages with an amqp reject in order to avoid issues with message order to the extent possible.

This code works, but include an interface change. Would something like this be feasible? Or am I missing something completely?