### PR TITLE
QPIDJMS-298 Add coverage report uploading to codecov.io in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ sudo: false
 jdk:
   - oraclejdk8
 after_success:
-  - mvn jacoco:report
+  - mvn jacoco:report jacoco:report-aggregate
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: java
 sudo: false
 jdk:
   - oraclejdk8
+after_success:
+  - mvn jacoco:report
+  - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <maven-idea-plugin-version>2.5</maven-idea-plugin-version>
     <maven-bundle-plugin-version>3.2.0</maven-bundle-plugin-version>
     <findbugs-maven-plugin-version>3.0.2</findbugs-maven-plugin-version>
-    <jacoco-plugin-version>0.7.5.201505241946</jacoco-plugin-version>
+    <jacoco-plugin-version>0.7.9</jacoco-plugin-version>
 
     <!-- Test properties -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>


### PR DESCRIPTION
You can review the report at https://codecov.io/gh/msgqe/qpid-jms/branch/codecov. There is also this nice feature of coverage diffs between commits (works only if both commits had been tested in CI before). It does not show much for this commit, because no java code was changed https://codecov.io/gh/msgqe/qpid-jms/commit/c1db46d8ee19c3eced459d0409eef6b78e4c5dae.

The project obviously needs to be enabled for codecov.io. I am not sure if that is a problem or not, given qpid-jms is an Apache project.

I choose codecov.io because it seems to have worked well for @ctron in https://github.com/ctron/kapua-gateway-client.