### PR TITLE
QPIDJMS-338 - Support setting keyStoreType and trustStoreType

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/TransportSslOptions.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/TransportSslOptions.java
@@ -46,7 +46,8 @@ public class TransportSslOptions extends TransportOptions {
     private String keyStorePassword;
     private String trustStoreLocation;
     private String trustStorePassword;
-    private String storeType = DEFAULT_STORE_TYPE;
+    private String keyStoreType = DEFAULT_STORE_TYPE;
+    private String trustStoreType = DEFAULT_STORE_TYPE;
     private String[] enabledCipherSuites;
     private String[] disabledCipherSuites;
     private String[] enabledProtocols;
@@ -126,18 +127,42 @@ public class TransportSslOptions extends TransportOptions {
     }
 
     /**
-     * @return the storeType
-     */
-    public String getStoreType() {
-        return storeType;
-    }
-
-    /**
      * @param storeType
      *        the format that the store files are encoded in.
      */
     public void setStoreType(String storeType) {
-        this.storeType = storeType;
+        setKeyStoreType(storeType);
+        setTrustStoreType(storeType);
+    }
+
+    /**
+     * @return the keyStoreType
+     */
+    public String getKeyStoreType() {
+        return keyStoreType;
+    }
+
+    /**
+     * @param keyStoreType
+     *        the format that the keyStore file is encoded in
+     */
+    public void setKeyStoreType(String keyStoreType) {
+        this.keyStoreType = keyStoreType;
+    }
+
+    /**
+     * @return the trustStoreType
+     */
+    public String getTrustStoreType() {
+        return trustStoreType;
+    }
+
+    /**
+     * @param trustStoreType
+     *        the format that the trustStore file is encoded in
+     */
+    public void setTrustStoreType(String trustStoreType) {
+        this.trustStoreType = trustStoreType;
     }
 
     /**
@@ -293,7 +318,8 @@ public class TransportSslOptions extends TransportOptions {
         copy.setKeyStorePassword(getKeyStorePassword());
         copy.setTrustStoreLocation(getTrustStoreLocation());
         copy.setTrustStorePassword(getTrustStorePassword());
-        copy.setStoreType(getStoreType());
+        copy.setKeyStoreType(getKeyStoreType());
+        copy.setTrustStoreType(getTrustStoreType());
         copy.setEnabledCipherSuites(getEnabledCipherSuites());
         copy.setDisabledCipherSuites(getDisabledCipherSuites());
         copy.setEnabledProtocols(getEnabledProtocols());

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/TransportSupport.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/TransportSupport.java
@@ -223,7 +223,7 @@ public class TransportSupport {
 
         String storeLocation = options.getTrustStoreLocation();
         String storePassword = options.getTrustStorePassword();
-        String storeType = options.getStoreType();
+        String storeType = options.getTrustStoreType();
 
         LOG.trace("Attempt to load TrustStore from location {} of type {}", storeLocation, storeType);
 
@@ -242,7 +242,7 @@ public class TransportSupport {
 
         String storeLocation = options.getKeyStoreLocation();
         String storePassword = options.getKeyStorePassword();
-        String storeType = options.getStoreType();
+        String storeType = options.getKeyStoreType();
         String alias = options.getKeyAlias();
 
         LOG.trace("Attempt to load KeyStore from location {} of type {}", storeLocation, storeType);

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/transports/TransportSslOptionsTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/transports/TransportSslOptionsTest.java
@@ -68,7 +68,8 @@ public class TransportSslOptionsTest extends QpidJmsTestCase {
         TransportSslOptions options = new TransportSslOptions();
 
         assertEquals(TransportSslOptions.DEFAULT_TRUST_ALL, options.isTrustAll());
-        assertEquals(TransportSslOptions.DEFAULT_STORE_TYPE, options.getStoreType());
+        assertEquals(TransportSslOptions.DEFAULT_STORE_TYPE, options.getKeyStoreType());
+        assertEquals(TransportSslOptions.DEFAULT_STORE_TYPE, options.getTrustStoreType());
 
         assertEquals(TransportSslOptions.DEFAULT_CONTEXT_PROTOCOL, options.getContextProtocol());
         assertNull(options.getEnabledProtocols());
@@ -102,7 +103,8 @@ public class TransportSslOptionsTest extends QpidJmsTestCase {
         assertEquals(PASSWORD, options.getKeyStorePassword());
         assertEquals(CLIENT_TRUSTSTORE, options.getTrustStoreLocation());
         assertEquals(PASSWORD, options.getTrustStorePassword());
-        assertEquals(KEYSTORE_TYPE, options.getStoreType());
+        assertEquals(KEYSTORE_TYPE, options.getKeyStoreType());
+        assertEquals(KEYSTORE_TYPE, options.getTrustStoreType());
         assertEquals(KEY_ALIAS, options.getKeyAlias());
         assertEquals(CONTEXT_PROTOCOL, options.getContextProtocol());
         assertEquals(SSL_CONTEXT, options.getSslContextOverride());
@@ -130,7 +132,8 @@ public class TransportSslOptionsTest extends QpidJmsTestCase {
         assertEquals(PASSWORD, options.getKeyStorePassword());
         assertEquals(CLIENT_TRUSTSTORE, options.getTrustStoreLocation());
         assertEquals(PASSWORD, options.getTrustStorePassword());
-        assertEquals(KEYSTORE_TYPE, options.getStoreType());
+        assertEquals(KEYSTORE_TYPE, options.getKeyStoreType());
+        assertEquals(KEYSTORE_TYPE, options.getTrustStoreType());
         assertEquals(KEY_ALIAS, options.getKeyAlias());
         assertEquals(CONTEXT_PROTOCOL, options.getContextProtocol());
         assertEquals(SSL_CONTEXT, options.getSslContextOverride());

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/transports/netty/NettySslTransportFactoryTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/transports/netty/NettySslTransportFactoryTest.java
@@ -57,6 +57,7 @@ public class NettySslTransportFactoryTest {
     public static final String[] CUSTOM_DISABLED_CIPHER_SUITES = {"Suite-3", "Suite-4"};
     public static final String CUSTOM_DISABLED_CIPHER_SUITES_STRING = "Suite-3,Suite-4";
     public static final String CUSTOM_STORE_TYPE = "jceks";
+    public static final String CUSTOM_STORE_TYPE_PKCS12 = "pkcs12";
     public static final boolean CUSTOM_TRUST_ALL = true;
     public static final boolean CUSTOM_VERIFY_HOST = false;
     public static final String CUSTOM_KEY_ALIAS = "myTestAlias";
@@ -94,7 +95,8 @@ public class NettySslTransportFactoryTest {
         assertArrayEquals(TransportSslOptions.DEFAULT_DISABLED_PROTOCOLS.toArray(new String[0]), sslOptions.getDisabledProtocols());
         assertNull(sslOptions.getEnabledCipherSuites());
 
-        assertEquals(TransportSslOptions.DEFAULT_STORE_TYPE, sslOptions.getStoreType());
+        assertEquals(TransportSslOptions.DEFAULT_STORE_TYPE, sslOptions.getKeyStoreType());
+        assertEquals(TransportSslOptions.DEFAULT_STORE_TYPE, sslOptions.getTrustStoreType());
         assertEquals(TransportSslOptions.DEFAULT_VERIFY_HOST, sslOptions.isVerifyHost());
         assertNull(sslOptions.getKeyAlias());
     }
@@ -176,9 +178,59 @@ public class NettySslTransportFactoryTest {
         List<String> customDisabledChiperSuites = Arrays.asList(CUSTOM_DISABLED_CIPHER_SUITES);
         assertThat(disabledCipherSuites, containsInAnyOrder(customDisabledChiperSuites.toArray()));
 
-        assertEquals(CUSTOM_STORE_TYPE, sslOptions.getStoreType());
+        assertEquals(CUSTOM_STORE_TYPE, sslOptions.getKeyStoreType());
+        assertEquals(CUSTOM_STORE_TYPE, sslOptions.getTrustStoreType());
         assertEquals(CUSTOM_VERIFY_HOST, sslOptions.isVerifyHost());
         assertEquals(CUSTOM_KEY_ALIAS, sslOptions.getKeyAlias());
         assertEquals(CUSTOM_CONTEXT_PROTOCOL, sslOptions.getContextProtocol());
+    }
+
+    @Test
+    public void testDifferentKeyStoreType() throws Exception {
+        URI BASE_URI = new URI("tcp://localhost:5672");
+        URI configuredURI = new URI(BASE_URI.toString() + "?" +
+            "transport.keyStoreType=" + CUSTOM_STORE_TYPE);
+
+        NettySslTransportFactory factory = new NettySslTransportFactory();
+        Transport transport = factory.createTransport(configuredURI);
+        TransportOptions options = transport.getTransportOptions();
+        assertTrue(options instanceof TransportSslOptions);
+        TransportSslOptions sslOptions = (TransportSslOptions) options;
+
+        assertEquals(CUSTOM_STORE_TYPE, sslOptions.getKeyStoreType());
+        assertEquals(TransportSslOptions.DEFAULT_STORE_TYPE, sslOptions.getTrustStoreType());
+    }
+
+    @Test
+    public void testDifferentTrustStoreType() throws Exception {
+        URI BASE_URI = new URI("tcp://localhost:5672");
+        URI configuredURI = new URI(BASE_URI.toString() + "?" +
+            "transport.trustStoreType=" + CUSTOM_STORE_TYPE);
+
+        NettySslTransportFactory factory = new NettySslTransportFactory();
+        Transport transport = factory.createTransport(configuredURI);
+        TransportOptions options = transport.getTransportOptions();
+        assertTrue(options instanceof TransportSslOptions);
+        TransportSslOptions sslOptions = (TransportSslOptions) options;
+
+        assertEquals(TransportSslOptions.DEFAULT_STORE_TYPE, sslOptions.getKeyStoreType());
+        assertEquals(CUSTOM_STORE_TYPE, sslOptions.getTrustStoreType());
+    }
+
+    @Test
+    public void testDifferentKeyStoreAndTrustStoreType() throws Exception {
+        URI BASE_URI = new URI("tcp://localhost:5672");
+        URI configuredURI = new URI(BASE_URI.toString() + "?" +
+                "transport.keyStoreType=" + CUSTOM_STORE_TYPE_PKCS12 + "&" +
+                "transport.trustStoreType=" + CUSTOM_STORE_TYPE);
+
+        NettySslTransportFactory factory = new NettySslTransportFactory();
+        Transport transport = factory.createTransport(configuredURI);
+        TransportOptions options = transport.getTransportOptions();
+        assertTrue(options instanceof TransportSslOptions);
+        TransportSslOptions sslOptions = (TransportSslOptions) options;
+
+        assertEquals(CUSTOM_STORE_TYPE_PKCS12, sslOptions.getKeyStoreType());
+        assertEquals(CUSTOM_STORE_TYPE, sslOptions.getTrustStoreType());
     }
 }


### PR DESCRIPTION
Qpid JMS now support setting the keyStoreType and trustStoreType to
different formats