### PR TITLE
QPIDJMS-340 - fix maven-assembly-plugin compatibility

### DIFF
--- a/apache-qpid-jms/pom.xml
+++ b/apache-qpid-jms/pom.xml
@@ -58,6 +58,7 @@
               <descriptors>
                 <descriptor>src/main/assembly/bin.xml</descriptor>
               </descriptors>
+              <tarLongFileMode>posix</tarLongFileMode>
             </configuration>
           </execution>
         </executions>
@@ -83,7 +84,7 @@
                   <descriptors>
                     <descriptor>src/main/assembly/src.xml</descriptor>
                   </descriptors>
-                  <tarLongFileMode>gnu</tarLongFileMode>
+                  <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Set targLongFileMode to posix for handling long file names