### PR TITLE
QPIDJMS-372: [SASL] [XOAUTH2] Make access token validation comply wit…

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/sasl/XOauth2Mechanism.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/sasl/XOauth2Mechanism.java
@@ -18,7 +18,7 @@ package org.apache.qpid.jms.sasl;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
-import java.util.Base64;
+import java.util.regex.Pattern;
 
 /**
  * Implements the SASL XOAUTH2 authentication Mechanism .
@@ -27,6 +27,7 @@ import java.util.Base64;
  */
 public class XOauth2Mechanism extends AbstractMechanism {
 
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("^[\\x20-\\x7F]+$");
     private String additionalFailureInformation;
 
     @Override
@@ -78,12 +79,7 @@ public class XOauth2Mechanism extends AbstractMechanism {
     @Override
     public boolean isApplicable(String username, String password, Principal localPrincipal) {
         if(username != null && username.length() > 0 && password != null && password.length() > 0) {
-            try {
-                Base64.getDecoder().decode(password);
-                return true;
-            } catch (IllegalArgumentException e) {
-                return false;
-            }
+            return ACCESS_TOKEN_PATTERN.matcher(password).matches();
         } else {
             return false;
         }

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/sasl/XOauth2MechanismTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/sasl/XOauth2MechanismTest.java
@@ -91,11 +91,12 @@ public class XOauth2MechanismTest {
         assertFalse("Should not be applicable with empty token", mech.isApplicable("user", "", null));
     }
 
+    /** RFC6749 defines the OAUTH2 an access token as comprising VSCHAR elements (\x20-7E) */
     @Test
-    public void testIsNotApplicableWithNonBase64Token() {
+    public void testIsNotApplicableWithIllegalAccessToken() {
         XOauth2Mechanism mech = new XOauth2Mechanism();
 
-        assertFalse("Should not be applicable with non base64 token", mech.isApplicable("user", "not base 64", null));
+        assertFalse("Should not be applicable with non vschars", mech.isApplicable("user", "illegalChar\000", null));
     }
 
 
@@ -110,14 +111,14 @@ public class XOauth2MechanismTest {
     public void testIsApplicableWithUserAndToken() {
         XOauth2Mechanism mech = new XOauth2Mechanism();
 
-        assertTrue("Should be applicable with user and token", mech.isApplicable("user", "YmFzZSA2NA==", null));
+        assertTrue("Should be applicable with user and token", mech.isApplicable("user", "2YotnFZFEjr1zCsicMWpAA", null));
     }
 
     @Test
     public void testIsApplicableWithUserAndPasswordAndPrincipal() {
         XOauth2Mechanism mech = new XOauth2Mechanism();
 
-        assertTrue("Should be applicable with user and token and principal", mech.isApplicable("user", "YmFzZSA2NA==", new Principal() {
+        assertTrue("Should be applicable with user and token and principal", mech.isApplicable("user", "2YotnFZFEjr1zCsicMWpAA", new Principal() {
             @Override
             public String getName() {
                 return "name";


### PR DESCRIPTION
Makes the client's validation of OAUTH-2 access tokens RFC-6749 compliant.