### PR TITLE
QPIDJMS-375: Added transport.ws.authorizationHeader option

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/TransportOptions.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/TransportOptions.java
@@ -33,6 +33,7 @@ public class TransportOptions implements Cloneable {
     public static final boolean DEFAULT_USE_EPOLL = true;
     public static final boolean DEFAULT_USE_KQUEUE = false;
     public static final boolean DEFAULT_TRACE_BYTES = false;
+    public static final String DEFAULT_AUTHORIZATION_HEADER = null;
 
     private int sendBufferSize = DEFAULT_SEND_BUFFER_SIZE;
     private int receiveBufferSize = DEFAULT_RECEIVE_BUFFER_SIZE;
@@ -46,6 +47,7 @@ public class TransportOptions implements Cloneable {
     private boolean useEpoll = DEFAULT_USE_EPOLL;
     private boolean useKQueue = DEFAULT_USE_KQUEUE;
     private boolean traceBytes = DEFAULT_TRACE_BYTES;
+    private String authorizationHeader = DEFAULT_AUTHORIZATION_HEADER;
 
     /**
      * @return the currently set send buffer size in bytes.
@@ -219,7 +221,15 @@ public class TransportOptions implements Cloneable {
         this.traceBytes = traceBytes;
     }
 
-    @Override
+    public String getAuthorizationHeader() {
+        return authorizationHeader;
+    }
+
+    public void setAuthorizationHeader(String authorizationHeader) {
+        this.authorizationHeader = authorizationHeader;
+    }
+
+  @Override
     public TransportOptions clone() {
         return copyOptions(new TransportOptions());
     }
@@ -240,6 +250,7 @@ public class TransportOptions implements Cloneable {
         copy.setDefaultTcpPort(getDefaultTcpPort());
         copy.setUseEpoll(isUseEpoll());
         copy.setTraceBytes(isTraceBytes());
+        copy.setAuthorizationHeader(getAuthorizationHeader());
 
         return copy;
     }

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/netty/NettyWsTransport.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/netty/NettyWsTransport.java
@@ -115,9 +115,14 @@ public class NettyWsTransport extends NettyTcpTransport {
         private final WebSocketClientHandshaker handshaker;
 
         public NettyWebSocketTransportHandler() {
+            String authHeader = getTransportOptions().getAuthorizationHeader();
+            DefaultHttpHeaders defHeaders = new DefaultHttpHeaders();
+            if(authHeader != null) {
+              defHeaders.add("Authorization", authHeader);
+            }
             handshaker = WebSocketClientHandshakerFactory.newHandshaker(
                 getRemoteLocation(), WebSocketVersion.V13, AMQP_SUB_PROTOCOL,
-                true, new DefaultHttpHeaders(), getMaxFrameSize());
+                true, defHeaders, getMaxFrameSize());
         }
 
         @Override


### PR DESCRIPTION
As described in the JIRA item: https://issues.apache.org/jira/browse/QPIDJMS-375

According tests will follow (however the {{NettyWsTransportTest}} and {{NettyEchoServer}} seems to fit not perfect for my test case).