### PR TITLE
Save allocation of new promise on each writeAndFlush

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/netty/NettyTcpTransport.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/netty/NettyTcpTransport.java
@@ -265,14 +265,14 @@ public class NettyTcpTransport implements Transport {
     public void write(ByteBuf output) throws IOException {
         checkConnected(output);
         LOG.trace("Attempted write of: {} bytes", output.readableBytes());
-        channel.write(output);
+        channel.write(output, channel.voidPromise());
     }
 
     @Override
     public void writeAndFlush(ByteBuf output) throws IOException {
         checkConnected(output);
         LOG.trace("Attempted write and flush of: {} bytes", output.readableBytes());
-        channel.writeAndFlush(output);
+        channel.writeAndFlush(output, channel.voidPromise());
     }
 
     @Override

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/netty/NettyWsTransport.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/transports/netty/NettyWsTransport.java
@@ -94,7 +94,7 @@ public class NettyWsTransport extends NettyTcpTransport {
 
         LOG.trace("Attempted write of: {} bytes", length);
 
-        channel.write(new BinaryWebSocketFrame(output));
+        channel.write(new BinaryWebSocketFrame(output), channel.voidPromise());
     }
 
     @Override
@@ -107,7 +107,7 @@ public class NettyWsTransport extends NettyTcpTransport {
 
         LOG.trace("Attempted write and flush of: {} bytes", length);
 
-        channel.writeAndFlush(new BinaryWebSocketFrame(output));
+        channel.writeAndFlush(new BinaryWebSocketFrame(output), channel.voidPromise());
     }
 
     @Override


### PR DESCRIPTION
Using a void promise on Netty writeAndFlush is possible to save
the allocation of a new one on each call.