### PR TITLE
Issue QPIDJMS-400: Add missing OSGI resolution:=optional to native tr…

### DIFF
--- a/qpid-jms-client/pom.xml
+++ b/qpid-jms-client/pom.xml
@@ -130,6 +130,8 @@
             <Bundle-SymbolicName>org.apache.qpid.jms.client</Bundle-SymbolicName>
             <Export-Package>org.apache.qpid.jms.*</Export-Package>
             <Import-Package>
+            io.netty.channel.epoll;resolution:="optional";version="[4.1.0,4.2.0)",
+            io.netty.channel.kqueue;resolution:="optional";version="[4.1.0,4.2.0)",
             io.netty.*;version="[4.1.0,4.2.0)",
             org.apache.qpid.proton.*;version="[0.27.1,0.28.0)",
             *</Import-Package>


### PR DESCRIPTION
…ansports

The packages io.netty.channel.epoll and io.netty.channel.kqueue need
to be marked as optional since only one of them can be activated at a
time depending on the target platform of choice. The OSGI system fails
to activate the bundle that does not match the platform where the
client is deployed and fails the application activation that attempts
to use it.