### PR TITLE
QPIDJMS-423 onConnectionEstablished(): log only main broker URI part.

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/JmsConnection.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/JmsConnection.java
@@ -1321,7 +1321,8 @@ public class JmsConnection implements AutoCloseable, Connection, TopicConnection
 
     @Override
     public void onConnectionEstablished(final URI remoteURI) {
-        LOG.info("Connection {} connected to remote Broker: {}", connectionInfo.getId(), remoteURI);
+        LOG.info("Connection {} connected to remote Broker: {}://{}:{}",
+                connectionInfo.getId(), remoteURI.getScheme(), remoteURI.getHost(), remoteURI.getPort());
         setMessageFactory(provider.getMessageFactory());
         connectionInfo.setConnectedURI(provider.getRemoteURI());
 


### PR DESCRIPTION
This commit changes a little bit the logging info in the onConnectionEstablished() method. URI query params do not need to be logged.

**Context**
The broker URI may contain sensitive info (like path to trust / key stores, and related **passwords**), and this info is being logged.

_Sample_:
```
<bean id="jmsConnectionFactory" class="org.apache.qpid.jms.JmsConnectionFactory">
    <constructor-arg name="remoteURI" value="amqps://some-location:5671?
transport.keyStoreLocation=/very/long/path/nnn-openssl.p12&amp;
transport.keyStorePassword=*******&amp;
transport.trustStoreLocation=/very/long/path/server.keystore&amp;
transport.trustStorePassword=*******"/>
</bean>
```



