### PR TITLE
QPIDJMS-461 Optimize the default message ID builder

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/JmsMessageProducer.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/JmsMessageProducer.java
@@ -64,7 +64,7 @@ public class JmsMessageProducer implements AutoCloseable, MessageProducer {
         this.anonymousProducer = destination == null;
 
         JmsMessageIDBuilder messageIDBuilder =
-            session.getMessageIDPolicy().getMessageIDBuilder(session, destination);
+            session.getMessageIDPolicy().getMessageIDBuilder(session, destination).initialize(producerId.toString());
 
         this.producerInfo = new JmsProducerInfo(producerId, messageIDBuilder);
         this.producerInfo.setDestination(destination);


### PR DESCRIPTION
Change the builtin Message ID builder to create a builder
per producer and optimize the string handling used to create
the Message ID from the producer id and sequence number.