### PR TITLE
QPIDJMS-483: Simplify Inheritance and Polymorphism Behavior for third…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
 
     <netty-transport-native-epoll-classifier>linux-x86_64</netty-transport-native-epoll-classifier>
     <netty-transport-native-kqueue-classifier>osx-x86_64</netty-transport-native-kqueue-classifier>
+    <avro.version>1.9.0</avro.version>
   </properties>
 
   <issueManagement>
@@ -225,6 +226,12 @@
         <artifactId>hadoop-minikdc</artifactId>
         <version>${hadoop-minikdc-version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+          <version>${avro.version}</version>
+          <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/qpid-jms-client/pom.xml
+++ b/qpid-jms-client/pom.xml
@@ -132,6 +132,11 @@
       <artifactId>opentracing-mock</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/message/JmsBytesMessage.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/message/JmsBytesMessage.java
@@ -34,16 +34,16 @@ public class JmsBytesMessage extends JmsMessage implements BytesMessage {
     protected transient DataOutputStream dataOut;
     protected transient DataInputStream dataIn;
 
-    private final JmsBytesMessageFacade facade;
+    private final JmsBytesMessageFacade jmsBytesMessageFacade;
 
-    public JmsBytesMessage(JmsBytesMessageFacade facade) {
-        super(facade);
-        this.facade = facade;
+    public JmsBytesMessage(JmsBytesMessageFacade jmsBytesMessageFacade) {
+        super(jmsBytesMessageFacade);
+        this.jmsBytesMessageFacade = jmsBytesMessageFacade;
     }
 
     @Override
     public JmsBytesMessage copy() throws JMSException {
-        JmsBytesMessage other = new JmsBytesMessage(facade.copy());
+        JmsBytesMessage other = new JmsBytesMessage(jmsBytesMessageFacade.copy());
         other.copy(this);
         return other;
     }
@@ -74,7 +74,7 @@ public class JmsBytesMessage extends JmsMessage implements BytesMessage {
     @Override
     public long getBodyLength() throws JMSException {
         initializeReading();
-        return facade.getBodyLength();
+        return jmsBytesMessageFacade.getBodyLength();
     }
 
     @Override
@@ -386,7 +386,7 @@ public class JmsBytesMessage extends JmsMessage implements BytesMessage {
 
     @Override
     public void reset() throws JMSException {
-        this.facade.reset();
+        this.jmsBytesMessageFacade.reset();
         this.dataOut = null;
         this.dataIn = null;
         setReadOnlyBody(true);
@@ -400,36 +400,36 @@ public class JmsBytesMessage extends JmsMessage implements BytesMessage {
 
     @Override
     public String toString() {
-        return "JmsBytesMessage { " + facade + " }";
+        return "JmsBytesMessage { " + jmsBytesMessageFacade + " }";
     }
 
     @Override
     public boolean isBodyAssignableTo(@SuppressWarnings("rawtypes") Class target) throws JMSException {
-        return facade.hasBody() ? target.isAssignableFrom(byte[].class) : true;
+        return jmsBytesMessageFacade.hasBody() ? target.isAssignableFrom(byte[].class) : true;
     }
 
     @Override
     protected <T> T doGetBody(Class<T> asType) throws JMSException {
         reset();
 
-        if (!facade.hasBody()) {
+        if (!jmsBytesMessageFacade.hasBody()) {
             return null;
         }
 
-        return (T) facade.copyBody();
+        return (T) jmsBytesMessageFacade.copyBody();
     }
 
     private void initializeWriting() throws JMSException {
         checkReadOnlyBody();
         if (this.dataOut == null) {
-            this.dataOut = new DataOutputStream(this.facade.getOutputStream());
+            this.dataOut = new DataOutputStream(this.jmsBytesMessageFacade.getOutputStream());
         }
     }
 
     private void initializeReading() throws JMSException {
         checkWriteOnlyBody();
         if (dataIn == null) {
-            dataIn = new DataInputStream(this.facade.getInputStream());
+            dataIn = new DataInputStream(this.jmsBytesMessageFacade.getInputStream());
         }
     }
 }

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/message/JmsBytesMessageOldForTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/message/JmsBytesMessageOldForTest.java
@@ -1,0 +1,417 @@
+package org.apache.qpid.jms.message;
+
+import org.apache.qpid.jms.exceptions.JmsExceptionSupport;
+import org.apache.qpid.jms.message.facade.JmsBytesMessageFacade;
+
+import javax.jms.BytesMessage;
+import javax.jms.JMSException;
+import javax.jms.MessageFormatException;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+
+class JmsBytesMessageOldForTest extends JmsMessage implements BytesMessage {
+
+    protected transient DataOutputStream dataOut;
+    protected transient DataInputStream dataIn;
+
+    private final JmsBytesMessageFacade facade;
+
+    public JmsBytesMessageOldForTest(JmsBytesMessageFacade facade) {
+        super(facade);
+        this.facade = facade;
+    }
+
+    @Override
+    public JmsBytesMessage copy() throws JMSException {
+        JmsBytesMessage other = new JmsBytesMessage(facade.copy());
+        other.copy(this);
+        return other;
+    }
+
+    private void copy(JmsBytesMessage other) throws JMSException {
+        super.copy(other);
+        this.dataOut = null;
+        this.dataIn = null;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public void clearBody() throws JMSException {
+        super.clearBody();
+        this.dataOut = null;
+        this.dataIn = null;
+    }
+
+    @Override
+    public long getBodyLength() throws JMSException {
+        initializeReading();
+        return facade.getBodyLength();
+    }
+
+    @Override
+    public boolean readBoolean() throws JMSException {
+        initializeReading();
+        try {
+            return this.dataIn.readBoolean();
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public byte readByte() throws JMSException {
+        initializeReading();
+        try {
+            return this.dataIn.readByte();
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.create(e);
+        }
+    }
+
+    @Override
+    public int readUnsignedByte() throws JMSException {
+        initializeReading();
+        try {
+            return this.dataIn.readUnsignedByte();
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public short readShort() throws JMSException {
+        initializeReading();
+        try {
+            return this.dataIn.readShort();
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public int readUnsignedShort() throws JMSException {
+        initializeReading();
+        try {
+            return this.dataIn.readUnsignedShort();
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public char readChar() throws JMSException {
+        initializeReading();
+        try {
+            return this.dataIn.readChar();
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public int readInt() throws JMSException {
+        initializeReading();
+        try {
+            return this.dataIn.readInt();
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public long readLong() throws JMSException {
+        initializeReading();
+        try {
+            return this.dataIn.readLong();
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public float readFloat() throws JMSException {
+        initializeReading();
+        try {
+            return this.dataIn.readFloat();
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public double readDouble() throws JMSException {
+        initializeReading();
+        try {
+            return this.dataIn.readDouble();
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public String readUTF() throws JMSException {
+        initializeReading();
+        try {
+            return this.dataIn.readUTF();
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public int readBytes(byte[] value) throws JMSException {
+        return readBytes(value, value.length);
+    }
+
+    @Override
+    public int readBytes(byte[] value, int length) throws JMSException {
+        initializeReading();
+
+        if (length < 0 || value.length < length) {
+            throw new IndexOutOfBoundsException(
+                    "length must not be negative or larger than the size of the provided array");
+        }
+
+        try {
+            int n = 0;
+            while (n < length) {
+                int count = this.dataIn.read(value, n, length - n);
+                if (count < 0) {
+                    break;
+                }
+                n += count;
+            }
+            if (n == 0 && length > 0) {
+                n = -1;
+            }
+            return n;
+        } catch (EOFException e) {
+            throw JmsExceptionSupport.createMessageEOFException(e);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public void writeBoolean(boolean value) throws JMSException {
+        initializeWriting();
+        try {
+            this.dataOut.writeBoolean(value);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public void writeByte(byte value) throws JMSException {
+        initializeWriting();
+        try {
+            this.dataOut.writeByte(value);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public void writeShort(short value) throws JMSException {
+        initializeWriting();
+        try {
+            this.dataOut.writeShort(value);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public void writeChar(char value) throws JMSException {
+        initializeWriting();
+        try {
+            this.dataOut.writeChar(value);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public void writeInt(int value) throws JMSException {
+        initializeWriting();
+        try {
+            this.dataOut.writeInt(value);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public void writeLong(long value) throws JMSException {
+        initializeWriting();
+        try {
+            this.dataOut.writeLong(value);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public void writeFloat(float value) throws JMSException {
+        initializeWriting();
+        try {
+            this.dataOut.writeFloat(value);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public void writeDouble(double value) throws JMSException {
+        initializeWriting();
+        try {
+            this.dataOut.writeDouble(value);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public void writeUTF(String value) throws JMSException {
+        initializeWriting();
+        try {
+            this.dataOut.writeUTF(value);
+        } catch (IOException ioe) {
+            throw JmsExceptionSupport.create(ioe);
+        }
+    }
+
+    @Override
+    public void writeBytes(byte[] value) throws JMSException {
+        initializeWriting();
+        try {
+            this.dataOut.write(value);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public void writeBytes(byte[] value, int offset, int length) throws JMSException {
+        initializeWriting();
+        try {
+            this.dataOut.write(value, offset, length);
+        } catch (IOException e) {
+            throw JmsExceptionSupport.createMessageFormatException(e);
+        }
+    }
+
+    @Override
+    public void writeObject(Object value) throws JMSException {
+        if (value == null) {
+            throw new NullPointerException();
+        }
+        initializeWriting();
+        if (value instanceof Boolean) {
+            writeBoolean(((Boolean) value).booleanValue());
+        } else if (value instanceof Character) {
+            writeChar(((Character) value).charValue());
+        } else if (value instanceof Byte) {
+            writeByte(((Byte) value).byteValue());
+        } else if (value instanceof Short) {
+            writeShort(((Short) value).shortValue());
+        } else if (value instanceof Integer) {
+            writeInt(((Integer) value).intValue());
+        } else if (value instanceof Long) {
+            writeLong(((Long) value).longValue());
+        } else if (value instanceof Float) {
+            writeFloat(((Float) value).floatValue());
+        } else if (value instanceof Double) {
+            writeDouble(((Double) value).doubleValue());
+        } else if (value instanceof String) {
+            writeUTF(value.toString());
+        } else if (value instanceof byte[]) {
+            writeBytes((byte[]) value);
+        } else {
+            throw new MessageFormatException("Cannot write non-primitive type:" + value.getClass());
+        }
+    }
+
+    @Override
+    public void reset() throws JMSException {
+        this.facade.reset();
+        this.dataOut = null;
+        this.dataIn = null;
+        setReadOnlyBody(true);
+    }
+
+    @Override
+    public void onSend(long producerTtl) throws JMSException {
+        reset();
+        super.onSend(producerTtl);
+    }
+
+    @Override
+    public String toString() {
+        return "JmsBytesMessage { " + facade + " }";
+    }
+
+    @Override
+    public boolean isBodyAssignableTo(@SuppressWarnings("rawtypes") Class target) throws JMSException {
+        return facade.hasBody() ? target.isAssignableFrom(byte[].class) : true;
+    }
+
+    @Override
+    protected <T> T doGetBody(Class<T> asType) throws JMSException {
+        reset();
+
+        if (!facade.hasBody()) {
+            return null;
+        }
+
+        return (T) facade.copyBody();
+    }
+
+    private void initializeWriting() throws JMSException {
+        checkReadOnlyBody();
+        if (this.dataOut == null) {
+            this.dataOut = new DataOutputStream(this.facade.getOutputStream());
+        }
+    }
+
+    private void initializeReading() throws JMSException {
+        checkWriteOnlyBody();
+        if (dataIn == null) {
+            dataIn = new DataInputStream(this.facade.getInputStream());
+        }
+    }
+}

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/message/JmsBytesMessageTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/message/JmsBytesMessageTest.java
@@ -38,6 +38,9 @@ import javax.jms.MessageFormatException;
 import javax.jms.MessageNotReadableException;
 import javax.jms.MessageNotWriteableException;
 
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.reflect.ReflectData;
 import org.apache.qpid.jms.message.facade.JmsBytesMessageFacade;
 import org.apache.qpid.jms.message.facade.test.JmsTestBytesMessageFacade;
 import org.apache.qpid.jms.message.facade.test.JmsTestMessageFactory;
@@ -1047,5 +1050,18 @@ public class JmsBytesMessageTest {
         assertTrue(message1.equals(message1));
         assertFalse(message1.equals(null));
         assertFalse(message1.equals(""));
+    }
+
+    //---------- Test for Avro serialization -------------------------------//
+
+    @Test
+    public void testSerializationWithAvro() throws Exception {
+        Schema schema = new ReflectData(JmsBytesMessage.class.getClassLoader()).getSchema(JmsBytesMessage.class);
+        assertNotNull(schema);
+    }
+
+    @Test(expected = AvroTypeException.class)
+    public void testSerializationThrowsAvroTypeException() throws Exception {
+        Schema schema = new ReflectData(JmsBytesMessageOldForTest.class.getClassLoader()).getSchema(JmsBytesMessageOldForTest.class);
     }
 }


### PR DESCRIPTION
When we use a third-party library for serialization (Avro in our case), polymorphism and inheritance are very problematic.
It would be highly desirable if we could simply rename a field (which is private) at the class JmsBytesMessage (facade attribute) by any other name so that serialization can work with Avro.
I sent you a pull request for this little job.
Thank you in advance
https://issues.apache.org/jira/browse/QPIDJMS-483