### PR TITLE
QPIDJMS-485: copy of AMQP bytes message includes the content type

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/message/AmqpJmsBytesMessageFacade.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/message/AmqpJmsBytesMessageFacade.java
@@ -63,7 +63,9 @@ public class AmqpJmsBytesMessageFacade extends AmqpJmsMessageFacade implements J
         copyInto(copy);
 
         Binary payload = getBinaryFromBody();
-        copy.setContentType(OCTET_STREAM_CONTENT_TYPE);
+        if (copy.getContentType() == null) {
+            copy.setContentType(OCTET_STREAM_CONTENT_TYPE);
+        }
         if (payload.getLength() > 0) {
             copy.setBody(new Data(payload));
         } else {

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/provider/amqp/message/AmqpJmsBytesMessageFacadeTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/provider/amqp/message/AmqpJmsBytesMessageFacadeTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.AmqpSequence;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.Data;
@@ -169,6 +170,19 @@ public class AmqpJmsBytesMessageFacadeTest extends AmqpJmsMessageTypesTestCase {
 
         assertDataBodyAsExpected(amqpBytesMessageFacade.getBody(), 0);
         assertDataBodyAsExpected(copy.getBody(), 0);
+    }
+    
+    @Test
+    public void testCopyIncludesContentType() throws Exception {
+        AmqpJmsBytesMessageFacade amqpBytesMessageFacade = createNewBytesMessageFacade();
+        amqpBytesMessageFacade.setContentType(Symbol.valueOf("application/xml"));
+        AmqpJmsBytesMessageFacade copy = amqpBytesMessageFacade.copy();
+        assertEquals("application/xml", copy.getContentType().toString());
+        
+        // check fallback as well
+        amqpBytesMessageFacade.setContentType(null);
+        copy = amqpBytesMessageFacade.copy();
+        assertEquals("application/octet-stream", copy.getContentType().toString());
     }
 
     /**


### PR DESCRIPTION
copy method of AmqpJmsBytesMessageFacade copies the content-type, if existing and falls back to application/octet-stream if not existing (as before)