### PR TITLE
Allow custom properties to be added to the connection

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/JmsConnectionFactory.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/JmsConnectionFactory.java
@@ -108,6 +108,7 @@ public class JmsConnectionFactory extends JNDIStorable implements ConnectionFact
     private ExceptionListener exceptionListener;
     private String tracing;
     private JmsTracer tracer;
+    private Map<String, String> customConnectionProperties;
 
     private JmsPrefetchPolicy prefetchPolicy = new JmsDefaultPrefetchPolicy();
     private JmsRedeliveryPolicy redeliveryPolicy = new JmsDefaultRedeliveryPolicy();
@@ -1025,6 +1026,26 @@ public class JmsConnectionFactory extends JNDIStorable implements ConnectionFact
      */
     public JmsTracer getTracer() {
         return tracer;
+    }
+    
+    /**
+     * Gets the custom connection properties that the user have set.
+     * 
+     * @return the custom properties set by the user.
+     */
+    public Map<String, String> getCustomConnectionProperties() {
+        return customConnectionProperties;
+    }
+
+    /**
+     * Sets the custom connection properties defined by the user.
+     * Properties containing the invalid character '=' in their key or value will not be sent with the connection.
+     * 
+     * @param customConnectionProperties
+     *      a Map<String, String> containing the custom properties set by the user.
+     */
+    public void setCustomConnectionProperties(Map<String, String> customConnectionProperties) {
+        this.customConnectionProperties = customConnectionProperties;
     }
 
     //----- Static Methods ---------------------------------------------------//

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/meta/JmsConnectionInfo.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/meta/JmsConnectionInfo.java
@@ -19,6 +19,7 @@ package org.apache.qpid.jms.meta;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.EnumMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
@@ -79,6 +80,7 @@ public final class JmsConnectionInfo extends JmsAbstractResource implements Comp
     private long closeTimeout = DEFAULT_CLOSE_TIMEOUT;
     private String queuePrefix = null;
     private String topicPrefix = null;
+    private Map<String, String> customConnectionProperties;
 
     private JmsPrefetchPolicy prefetchPolicy;
     private JmsRedeliveryPolicy redeliveryPolicy;
@@ -441,5 +443,13 @@ public final class JmsConnectionInfo extends JmsAbstractResource implements Comp
 
     public JmsTracer getTracer() {
         return tracer;
+    }
+
+    public Map<String, String> getCustomConnectionProperties() {
+        return customConnectionProperties;
+    }
+
+    public void setCustomConnectionProperties(Map<String, String> customConnectionProperties) {
+        this.customConnectionProperties = customConnectionProperties;
     }
 }

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/builders/AmqpConnectionBuilder.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/builders/AmqpConnectionBuilder.java
@@ -118,6 +118,12 @@ public class AmqpConnectionBuilder extends AmqpResourceBuilder<AmqpConnection, A
         props.put(AmqpSupport.VERSION, MetaDataSupport.PROVIDER_VERSION);
         props.put(AmqpSupport.PLATFORM, MetaDataSupport.PLATFORM_DETAILS);
 
+        if (resourceInfo.getCustomConnectionProperties() != null) {
+            for (Map.Entry<String, String> entry : resourceInfo.getCustomConnectionProperties().entrySet()) {
+                props.put(Symbol.valueOf(entry.getKey()), entry.getValue());
+            }
+        }
+        
         Connection connection = getParent().getProtonConnection();
         connection.setHostname(hostname);
         connection.setContainer(resourceInfo.getClientId());

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/util/PropertyUtil.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/util/PropertyUtil.java
@@ -341,6 +341,8 @@ public class PropertyUtil {
                             properties.put(pd.getName(), ("" + value));
                         } else if (value instanceof SSLContext) {
                             // ignore this one..
+                        } else if (value instanceof Map) {
+                            properties.put(pd.getName(), value.toString());
                         } else {
                             Map<String, String> inner = getProperties(value);
                             for (Map.Entry<String, String> entry : inner.entrySet()) {

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/util/TypeConversionSupport.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/util/TypeConversionSupport.java
@@ -18,6 +18,7 @@ package org.apache.qpid.jms.util;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 
 public final class TypeConversionSupport {
 
@@ -154,6 +155,13 @@ public final class TypeConversionSupport {
                 return Double.valueOf(((Number) value).doubleValue());
             }
         });
+
+        CONVERSION_MAP.put(new ConversionKey(String.class, Map.class), new Converter() {
+            @Override
+            public Object convert(Object value) {
+                return convertStringToStringMap((String) value);
+            }
+        });
     }
 
     public static Object convert(Object value, Class<?> toClass) {
@@ -203,6 +211,38 @@ public final class TypeConversionSupport {
         }
 
         return rc;
+    }
+
+    // This method does not handle types outside of String
+    private static Map<String, String> convertStringToStringMap(String string) {
+        Map<String, String> map = new HashMap<String, String>();
+        boolean returnNull = false;
+
+        try {
+            if (string == null) {
+                return null;
+            }
+
+            if (string.startsWith("{") && string.endsWith("}")) {
+                string = string.substring(1, string.length() - 1);
+            }
+
+            String[] pairs = string.split(",");
+            for (String pair : pairs) {
+                String[] keyValue = pair.split("=");
+                if (keyValue.length == 2) {
+                    map.put(keyValue[0], keyValue[1]);
+                }
+            }
+        } catch (Exception e) {
+            returnNull = true;
+        } finally {
+            if (returnNull) {
+                map = null;
+            }
+        }
+
+        return map;
     }
 
     private TypeConversionSupport() {}

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/JmsConnectionFactoryTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/JmsConnectionFactoryTest.java
@@ -367,6 +367,18 @@ public class JmsConnectionFactoryTest extends QpidJmsTestCase {
     }
 
     @Test
+    public void testSetCustomConnectionProperties() {
+        Map<String, String> customProperties = new HashMap<String, String>();
+        customProperties.put("key", "value");
+        
+        JmsConnectionFactory cf = new JmsConnectionFactory();
+        assertNotEquals("custom properties should not have been set yet", customProperties, cf.getCustomConnectionProperties());
+        
+        cf.setCustomConnectionProperties(customProperties);
+        assertEquals("custom properties should have been set", customProperties, cf.getCustomConnectionProperties());
+    }
+    
+    @Test
     public void testSetPropertiesWithUnusedOptions() throws Exception {
         String uri = "amqp://localhost:1234";
         String unusedKey = "unusedKey";

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/util/TypeConversionSupportTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/util/TypeConversionSupportTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -307,5 +309,14 @@ public class TypeConversionSupportTest {
         boolean result = (boolean) TypeConversionSupport.convert(true, Boolean.class);
         assertNotNull(result);
         assertTrue(result);
+    }
+
+    //----- Map conversion from String --------------------------//
+    @Test
+    public void testStringToStringMap() {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("key", "value");
+        Map<String, String> result = (Map<String, String>) TypeConversionSupport.convert(map.toString(), Map.class);
+        assertEquals(map, result);
     }
 }


### PR DESCRIPTION
Allow custom properties to be added as Map<String, String> to be sent over the JMS Connection.