### PR TITLE
Compare hostname instead of IP to avoid uris being discared

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/failover/FailoverUriPool.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/failover/FailoverUriPool.java
@@ -318,8 +318,15 @@ public class FailoverUriPool {
                 firstAddr = InetAddress.getByName(first.getHost());
                 secondAddr = InetAddress.getByName(second.getHost());
 
-                if (firstAddr.equals(secondAddr)) {
-                    result = true;
+                // only compare IP addresses if it's a loopback address.
+                if (firstAddr.isLoopbackAddress() || secondAddr.isLoopbackAddress()){
+                    if (firstAddr.equals(secondAddr)) {
+                        result = true;
+                    }
+                }else{
+                    if(first.getHost().equalsIgnoreCase(second.getHost())){
+                        result = true;
+                    }
                 }
             } catch (IOException e) {
                 if (firstAddr == null) {


### PR DESCRIPTION
There is an issue when the a client tries to reach AMQP brokers are behind an HAProxy with TLS/SNI routing such as when deployed on Openshift and exposed through Openshift Routes.
Hostnames that are mentioned in the list of failover uris are discarded as they resolve to the same IP address. Comparing URI's should resolve to IP addresses only when it's a loopback address, otherwise the hostnames should be used to avoid being discarded.
