### PR TITLE
Remove InetAddress.getByName lookup for compare

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/failover/FailoverUriPool.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/failover/FailoverUriPool.java
@@ -312,25 +312,8 @@ public class FailoverUriPool {
         }
 
         if (first.getPort() == second.getPort()) {
-            InetAddress firstAddr = null;
-            InetAddress secondAddr = null;
-            try {
-                firstAddr = InetAddress.getByName(first.getHost());
-                secondAddr = InetAddress.getByName(second.getHost());
-
-                if (firstAddr.equals(secondAddr)) {
-                    result = true;
-                }
-            } catch (IOException e) {
-                if (firstAddr == null) {
-                    LOG.error("Failed to Lookup INetAddress for URI[ " + first + " ] : " + e);
-                } else {
-                    LOG.error("Failed to Lookup INetAddress for URI[ " + second + " ] : " + e);
-                }
-
-                if (first.getHost().equalsIgnoreCase(second.getHost())) {
-                    result = true;
-                }
+            if (first.getHost().equalsIgnoreCase(second.getHost())) {
+                result = true;
             }
         }
 

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/provider/failover/FailoverUriPoolTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/provider/failover/FailoverUriPoolTest.java
@@ -157,15 +157,15 @@ public class FailoverUriPoolTest extends QpidJmsTestCase {
 
         assertEquals(1, pool.size());
         pool.add(new URI("tcp://localhost:5672?transport.tcpNoDelay=true"));
-        assertEquals(1, pool.size());
+        assertEquals(2, pool.size());
 
-        assertEquals(1, pool.size());
+        assertEquals(2, pool.size());
         pool.add(new URI("tcp://localhost:5672?transport.tcpNoDelay=false"));
-        assertEquals(1, pool.size());
+        assertEquals(2, pool.size());
     }
 
     @Test
-    public void testDuplicatesNotAddedWithHostResolution() throws URISyntaxException {
+    public void testDuplicatesNotAddedWithoutHostResolution() throws URISyntaxException {
         FailoverUriPool pool = new FailoverUriPool();
 
         assertTrue(pool.isEmpty());
@@ -174,11 +174,11 @@ public class FailoverUriPoolTest extends QpidJmsTestCase {
 
         assertEquals(1, pool.size());
         pool.add(new URI("tcp://localhost:5672"));
-        assertEquals(1, pool.size());
-
-        assertEquals(1, pool.size());
-        pool.add(new URI("tcp://localhost:5673"));
         assertEquals(2, pool.size());
+
+        assertEquals(2, pool.size());
+        pool.add(new URI("tcp://localhost:5673"));
+        assertEquals(3, pool.size());
     }
 
     @Test
@@ -353,22 +353,18 @@ public class FailoverUriPoolTest extends QpidJmsTestCase {
         assertTrue(pool.isEmpty());
         pool.add(new URI("tcp://127.0.0.1:5672?transport.tcpNoDelay=true"));
         assertFalse(pool.isEmpty());
-        pool.remove(new URI("tcp://localhost:5672?transport.tcpNoDelay=true"));
-        assertTrue(pool.isEmpty());
-        pool.add(new URI("tcp://127.0.0.1:5672?transport.tcpNoDelay=true"));
-        assertFalse(pool.isEmpty());
-        pool.remove(new URI("tcp://localhost:5672?transport.tcpNoDelay=false"));
+        pool.remove(new URI("tcp://127.0.0.1:5672?transport.tcpNoDelay=true"));
         assertTrue(pool.isEmpty());
     }
 
     @Test
-    public void testRemoveWithHostResolution() throws URISyntaxException {
+    public void testRemove() throws URISyntaxException {
         FailoverUriPool pool = new FailoverUriPool();
 
         assertTrue(pool.isEmpty());
         pool.add(new URI("tcp://127.0.0.1:5672"));
         assertFalse(pool.isEmpty());
-        pool.remove(new URI("tcp://localhost:5672"));
+        pool.remove(new URI("tcp://127.0.0.1:5672"));
         assertTrue(pool.isEmpty());
         pool.add(new URI("tcp://127.0.0.1:5672"));
         assertFalse(pool.isEmpty());


### PR DESCRIPTION
URIs should be able to resolve to the same IP address, as the brokers may be running behind a proxy.

For example, I have a container-based broker setup running in Kubernetes and I am exposing the brokers through the use of Kubernetes ingress (OpenShift Routes, to be exact). The brokers have different route URIs but they always will resolve back to the HAProxy running as a load balancer in front of the Kubernetes cluster.

Example: failover:(amqps://ex-aao-amqp-2-svc-rte-amq-broker.apps.ocp.domain.com:443,amqps://ex-aao-amqp-0-svc-rte-amq-broker.apps.ocp.domain.com:443)

Both ex-aao-amqp-0-svc-rte-amq-broker.apps.ocp.domain.com and ex-aao-amqp-2-svc-rte-amq-broker.apps.ocp.domain.com will both resolve to the exact same IP address because those addresses resolve to the HAProxy running in front of OpenShift.

The new logic ignores the ultimately resolved IP addresses as the comparison method and instead simply compares the equality of the strings.