### PR TITLE
QPIDJMS-548: support taking principle and credentials from context

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/jndi/JmsInitialContextFactory.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/jndi/JmsInitialContextFactory.java
@@ -80,6 +80,14 @@ public class JmsInitialContextFactory implements InitialContextFactory {
                 String expanded = expand(location, environmentCopy);
                 if (ProviderFactory.findProviderFactory(new URI(expanded)) != null) {
                     environmentCopy.put(CONNECTION_FACTORY_DEFAULT_KEY_PREFIX + REMOTE_URI_PROP, expanded);
+                    String principle = environmentCopy.containsKey(Context.SECURITY_PRINCIPAL) ? (String) environment.get(Context.SECURITY_PRINCIPAL) : System.getProperty(Context.SECURITY_PRINCIPAL);
+                    if (principle != null) {
+                        environmentCopy.put(CONNECTION_FACTORY_DEFAULT_KEY_PREFIX + "username", principle);
+                    }
+                    String credentials = environmentCopy.containsKey(Context.SECURITY_CREDENTIALS) ? (String) environment.get(Context.SECURITY_CREDENTIALS) : System.getProperty(Context.SECURITY_CREDENTIALS);
+                    if (credentials != null) {
+                        environmentCopy.put(CONNECTION_FACTORY_DEFAULT_KEY_PREFIX + "password", credentials);
+                    }
                     providerUri = true;
                 }
             } catch (IOException | URISyntaxException e) {

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/jndi/JmsInitialContextFactoryTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/jndi/JmsInitialContextFactoryTest.java
@@ -663,4 +663,20 @@ public class JmsInitialContextFactoryTest extends QpidJmsTestCase {
         doSetDefaultFactoryUriViaProviderURLTestImpl("failover:(amqp://host1:5672,amqp://host2:5672)");
         doSetDefaultFactoryUriViaProviderURLTestImpl("failover:(amqps://host1:5672,amqps://host2:5672)");
     }
+
+    @Test
+    public void testProvidingDefaultFactoryRemoteUriViaProviderURLWithContextCredentials() throws NamingException {
+        Properties env = new Properties();
+        env.setProperty(Context.INITIAL_CONTEXT_FACTORY, JmsInitialContextFactory.class.getName());
+        env.setProperty(Context.PROVIDER_URL, "failover:(amqps://host1:5672,amqps://host2:5672)");
+        env.setProperty(Context.SECURITY_PRINCIPAL, "myuser");
+        env.setProperty(Context.SECURITY_CREDENTIALS, "mypassword");
+
+        Context context = createInitialContext(env);
+
+        ConnectionFactory connectionFactory = (ConnectionFactory) context.lookup("ConnectionFactory");
+        assertTrue(connectionFactory instanceof JmsConnectionFactory);
+        assertEquals("myuser", ((JmsConnectionFactory) connectionFactory).getUsername());
+        assertEquals("mypassword", ((JmsConnectionFactory) connectionFactory).getPassword());
+    }
 }


### PR DESCRIPTION
Add mapping from jndi principle and credentials to username and password for the default connection factory when using provider url 
Add test case