### PR TITLE
QPIDJMS-552 JMS 2 Completion threads shouldn't scale with the number of sessions

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/meta/JmsConnectionInfo.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/meta/JmsConnectionInfo.java
@@ -20,7 +20,10 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.EnumMap;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 import javax.jms.Connection;
 
@@ -38,6 +41,7 @@ import org.apache.qpid.jms.policy.JmsPresettlePolicy;
 import org.apache.qpid.jms.policy.JmsRedeliveryPolicy;
 import org.apache.qpid.jms.tracing.JmsNoOpTracer;
 import org.apache.qpid.jms.tracing.JmsTracer;
+import org.apache.qpid.jms.util.RefPool.Ref;
 
 /**
  * Meta object that contains the JmsConnection identification and configuration
@@ -50,6 +54,7 @@ public final class JmsConnectionInfo extends JmsAbstractResource implements Comp
     public static final long DEFAULT_CLOSE_TIMEOUT = 60000;
     public static final long DEFAULT_SEND_TIMEOUT = INFINITE;
     public static final long DEFAULT_REQUEST_TIMEOUT = INFINITE;
+    public static final int DEFAULT_COMPLETION_THREADS = 0;
 
     private final JmsConnectionId connectionId;
     private final EnumMap<JmsConnectionExtensions, BiFunction<Connection, URI, Object>> extensionMap = new EnumMap<>(JmsConnectionExtensions.class);
@@ -89,6 +94,7 @@ public final class JmsConnectionInfo extends JmsAbstractResource implements Comp
 
     private volatile byte[] encodedUserId;
     private JmsTracer tracer = JmsNoOpTracer.INSTANCE;
+    private Optional<Supplier<Ref<ExecutorService>>> completionExecutorServiceFactory;
 
     public JmsConnectionInfo(JmsConnectionId connectionId) {
         if (connectionId == null) {
@@ -451,5 +457,16 @@ public final class JmsConnectionInfo extends JmsAbstractResource implements Comp
 
     public JmsTracer getTracer() {
         return tracer;
+    }
+
+    public void setCompletionExecutorServiceFactory(final Supplier<Ref<ExecutorService>> completionExecutorServiceFactory) {
+        this.completionExecutorServiceFactory = Optional.ofNullable(completionExecutorServiceFactory);
+    }
+
+    public Optional<Supplier<Ref<ExecutorService>>> getCompletionExecutorServiceFactory() {
+        if (completionExecutorServiceFactory == null) {
+            return Optional.empty();
+        }
+        return completionExecutorServiceFactory;
     }
 }

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/util/QpidJMSForkJoinWorkerThreadFactory.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/util/QpidJMSForkJoinWorkerThreadFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.qpid.jms.util;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple {@link ForkJoinPool.ForkJoinWorkerThreadFactory} object
+ */
+public class QpidJMSForkJoinWorkerThreadFactory implements ForkJoinPool.ForkJoinWorkerThreadFactory {
+
+   private static final Logger LOG = LoggerFactory.getLogger(QpidJMSForkJoinWorkerThreadFactory.class);
+
+   private final String threadName;
+   private final boolean daemon;
+
+   /**
+    * Creates a new Thread factory that will create threads with the
+    * given name and daemon state.
+    *
+    * @param threadName the name that will be used for each thread created.
+    * @param daemon     should the created thread be a daemon thread.
+    */
+   public QpidJMSForkJoinWorkerThreadFactory(String threadName, boolean daemon) {
+      this.threadName = threadName;
+      this.daemon = daemon;
+   }
+
+   @Override
+   public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
+
+      final ForkJoinWorkerThread thread = new ForkJoinWorkerThread(pool) {
+
+      };
+      thread.setName(threadName);
+      thread.setDaemon(daemon);
+      thread.setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
+
+         @Override
+         public void uncaughtException(Thread target, Throwable error) {
+            LOG.warn("Thread: {} failed due to an uncaught exception: {}", target.getName(), error.getMessage());
+            LOG.trace("Uncaught Stacktrace: ", error);
+         }
+      });
+
+      return thread;
+   }
+}

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/util/RefPool.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/util/RefPool.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.qpid.jms.util;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class RefPool {
+
+   public interface Ref<T> extends AutoCloseable {
+
+      T ref();
+
+      @Override
+      void close();
+   }
+
+   public static <T> Supplier<Ref<T>> shared(final Supplier<? extends T> create,
+                                             final Consumer<? super T> onDispose) {
+      return new SharedRefPool<>(create, onDispose);
+   }
+}

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/util/SharedRefPool.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/util/SharedRefPool.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.qpid.jms.util;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.apache.qpid.jms.util.RefPool.Ref;
+
+final class SharedRefPool<T> implements Supplier<Ref<T>>{
+
+   private static final class AtomicCloseableRef<T> implements Ref<T> {
+
+      private final Ref<T> sharedRef;
+      private final AtomicBoolean closed;
+
+      public AtomicCloseableRef(final Ref<T> sharedRef) {
+         this.sharedRef = sharedRef;
+         this.closed = new AtomicBoolean();
+      }
+
+      @Override
+      public T ref() {
+         return sharedRef.ref();
+      }
+
+      @Override
+      public void close() {
+         if (closed.compareAndSet(false, true)) {
+            sharedRef.close();
+         }
+      }
+   }
+
+   private static final class SharedRef<T> implements Ref<T> {
+
+      private final T ref;
+      private final AtomicInteger refCnt;
+      private final Consumer<? super SharedRef<T>> onDispose;
+
+      public SharedRef(final T ref, final Consumer<? super SharedRef<T>> onDispose) {
+         this.ref = ref;
+         this.refCnt = new AtomicInteger(1);
+         this.onDispose = onDispose;
+      }
+
+      public boolean retain() {
+         while (true) {
+            final int currValue = refCnt.get();
+            if (currValue == 0) {
+               // this has been already disposed!
+               return false;
+            }
+            if (refCnt.compareAndSet(currValue, currValue + 1)) {
+               return true;
+            }
+         }
+      }
+
+      @Override
+      public T ref() {
+         if (refCnt.get() == 0) {
+            throw new IllegalStateException("the ref cannot be used anymore");
+         }
+         return ref;
+      }
+
+      @Override
+      public void close() {
+         while (true) {
+            final int currValue = refCnt.get();
+            if (currValue == 0) {
+               return;
+            }
+            if (refCnt.compareAndSet(currValue, currValue - 1)) {
+               if (currValue == 1) {
+                  onDispose.accept(this);
+               }
+               return;
+            }
+         }
+      }
+   }
+
+   private final Supplier<? extends T> create;
+   private final Consumer<? super T> onDispose;
+   private final AtomicReference<SharedRef<T>> sharedRef = new AtomicReference<>(null);
+
+   public SharedRefPool(final Supplier<? extends T> create, final Consumer<? super T> onDispose) {
+      this.create = create;
+      this.onDispose = onDispose;
+   }
+
+   @Override
+   public Ref<T> get() {
+      while (true) {
+         SharedRef<T> sharedRef = this.sharedRef.get();
+         if (sharedRef != null && sharedRef.retain()) {
+            return new AtomicCloseableRef(sharedRef);
+         }
+         synchronized (this) {
+            sharedRef = this.sharedRef.get();
+            if (sharedRef != null && sharedRef.retain()) {
+               return new AtomicCloseableRef(sharedRef);
+            }
+            sharedRef = new SharedRef<>(create.get(), self -> {
+               // help GC in case no racing get would replace
+               this.sharedRef.compareAndSet(self, null);
+               onDispose.accept(self.ref);
+            });
+            this.sharedRef.set(sharedRef);
+            return new AtomicCloseableRef(sharedRef);
+         }
+      }
+   }
+}


### PR DESCRIPTION
This implements an elastic per-connection thread pool that allows session completions to be consumed in order (as now) while saving create a dedicated thread per session.

In a shared connection use case, multiple sessions can benefit from re-using the same thread to handle their completions, reducing dramatically both wake-up cost and (native) memory usage.   

In the case where each session is using its own connection, it would behave as the previous implementation.