### PR TITLE
Update ExternalMechanism.java to be RFC compliant

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/sasl/ExternalMechanism.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/sasl/ExternalMechanism.java
@@ -16,6 +16,7 @@
  */
 package org.apache.qpid.jms.sasl;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 
 /**

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/sasl/ExternalMechanism.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/sasl/ExternalMechanism.java
@@ -25,7 +25,11 @@ public class ExternalMechanism extends AbstractMechanism {
 
     @Override
     public byte[] getInitialResponse() {
-        return EMPTY;
+        String username = getUsername();
+        if(username == null || username.isEmpty()){
+            return EMPTY;
+          }
+        return username.getBytes(StandardCharsets.UTF_8);
     }
 
     @Override


### PR DESCRIPTION
[RFC](https://datatracker.ietf.org/doc/html/rfc4422#appendix-A.1)

SASL External mechanism is capable of transferring an authorization identity string. The client sends the initial response to the intial challenge by the server. It can be empty or non-empty.

Response is non-empty when the client is requesting to act as the identity represented by the (non-empty) string which is UTF-8 encoding of the requested authorization identity string. It is empty when the client is requesting to act as the identity the server associated with its authentication credentials

### Why Apache qpid-jms doesn't support identity string?

The SASL External mechanism is configured in this class (ExternalMechanism.java) of Apache qpid-jms.

We can notice that the initial response is configured in Line 28. It is always set to EMPTY (empty byte array defined here) and cannot be configured to a custom string that we can use as identity string. Hence this library is NOT RFC compliant

If we have to pass the authorization identity string to the server then we must configure the initial response of that client.