### PR TITLE
[QPIDJMS-624] Also support non-byte type-annotations

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/message/AmqpDestinationHelper.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/message/AmqpDestinationHelper.java
@@ -277,9 +277,9 @@ public class AmqpDestinationHelper {
         if (typeAnnotation == null) {
             // Doesn't exist, or null.
             return UNKNOWN_TYPE;
-        } else if (typeAnnotation instanceof Byte) {
-            // Return the value found.
-            return (Byte) typeAnnotation;
+        } else if (typeAnnotation instanceof Number) {
+            // Return the found value as a byte.
+            return ((Number)typeAnnotation).byteValue();
         } else {
             // Handle legacy strings.
             String typeString = String.valueOf(typeAnnotation);

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/provider/amqp/message/AmqpDestinationHelperTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/provider/amqp/message/AmqpDestinationHelperTest.java
@@ -44,6 +44,7 @@ import org.apache.qpid.jms.JmsTemporaryQueue;
 import org.apache.qpid.jms.JmsTemporaryTopic;
 import org.apache.qpid.jms.JmsTopic;
 import org.apache.qpid.jms.provider.amqp.AmqpConnection;
+import org.apache.qpid.proton.amqp.UnsignedByte;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -684,6 +685,34 @@ public class AmqpDestinationHelperTest {
         JmsDestination destination = AmqpDestinationHelper.getJmsReplyTo(message, null);
         assertNotNull(destination);
         assertTrue(destination.isTopic());
+        assertTrue(destination.isTemporary());
+        assertEquals(testAddress, destination.getAddress());
+    }
+
+    @Test
+    public void testGetJmsReplToWithTempQueueUnsignedByteTypeAnnotation() throws Exception {
+        String testAddress = "testAddress";
+        AmqpJmsMessageFacade message = Mockito.mock(AmqpJmsMessageFacade.class);
+        Mockito.when(message.getReplyToAddress()).thenReturn(testAddress);
+        Mockito.when(message.getMessageAnnotation(JMS_REPLY_TO_TYPE_MSG_ANNOTATION_SYMBOL)).thenReturn(UnsignedByte.valueOf(TEMP_QUEUE_TYPE));
+
+        JmsDestination destination = AmqpDestinationHelper.getJmsReplyTo(message, null);
+        assertNotNull(destination);
+        assertTrue(destination.isQueue());
+        assertTrue(destination.isTemporary());
+        assertEquals(testAddress, destination.getAddress());
+    }
+
+    @Test
+    public void testGetJmsReplToWithTempQueueLongTypeAnnotation() throws Exception {
+        String testAddress = "testAddress";
+        AmqpJmsMessageFacade message = Mockito.mock(AmqpJmsMessageFacade.class);
+        Mockito.when(message.getReplyToAddress()).thenReturn(testAddress);
+        Mockito.when(message.getMessageAnnotation(JMS_REPLY_TO_TYPE_MSG_ANNOTATION_SYMBOL)).thenReturn((long) TEMP_QUEUE_TYPE);
+
+        JmsDestination destination = AmqpDestinationHelper.getJmsReplyTo(message, null);
+        assertNotNull(destination);
+        assertTrue(destination.isQueue());
         assertTrue(destination.isTemporary());
         assertEquals(testAddress, destination.getAddress());
     }


### PR DESCRIPTION
NMS AMQP is using "byte" which are unsigned in dotnet. Yes, this is non-std compatible, but not handling these values is also non-std compatible.
It's a MUST to sent data as signed byte.
But it's also a MUST to read other numeric values in the type-annotations fields in the binding spec.

This is related to https://github.com/apache/activemq-nms-amqp/pull/101