### PR TITLE
Make constants for custom acknowledge modes public

### DIFF
--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/JmsSession.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/JmsSession.java
@@ -108,9 +108,9 @@ public class JmsSession implements AutoCloseable, Session, QueueSession, TopicSe
 
     private static final Logger LOG = LoggerFactory.getLogger(JmsSession.class);
 
-    private static final int INDIVIDUAL_ACKNOWLEDGE = 101;
-    private static final int ARTEMIS_PRE_ACKNOWLEDGE = 100;
-    private static final int NO_ACKNOWLEDGE = 257;
+    public static final int INDIVIDUAL_ACKNOWLEDGE = 101;
+    public static final int ARTEMIS_PRE_ACKNOWLEDGE = 100;
+    public static final int NO_ACKNOWLEDGE = 257;
 
     private final JmsConnection connection;
     private final int acknowledgementMode;

--- a/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/AmqpConsumer.java
+++ b/qpid-jms-client/src/main/java/org/apache/qpid/jms/provider/amqp/AmqpConsumer.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ScheduledFuture;
 import jakarta.jms.Session;
 
 import org.apache.qpid.jms.JmsDestination;
+import org.apache.qpid.jms.JmsSession;
 import org.apache.qpid.jms.message.JmsInboundMessageDispatch;
 import org.apache.qpid.jms.message.JmsMessage;
 import org.apache.qpid.jms.meta.JmsConsumerId;
@@ -54,8 +55,6 @@ import org.slf4j.LoggerFactory;
 public class AmqpConsumer extends AmqpAbstractResource<JmsConsumerInfo, Receiver> {
 
     private static final Logger LOG = LoggerFactory.getLogger(AmqpConsumer.class);
-
-    private static final int INDIVIDUAL_ACKNOWLEDGE = 101;
 
     protected final AmqpSession session;
     protected final int acknowledgementMode;
@@ -91,7 +90,7 @@ public class AmqpConsumer extends AmqpAbstractResource<JmsConsumerInfo, Receiver
         if (acknowledgementMode == Session.CLIENT_ACKNOWLEDGE
                 || acknowledgementMode == Session.AUTO_ACKNOWLEDGE
                     || acknowledgementMode == Session.DUPS_OK_ACKNOWLEDGE
-                        || acknowledgementMode == INDIVIDUAL_ACKNOWLEDGE) {
+                        || acknowledgementMode == JmsSession.INDIVIDUAL_ACKNOWLEDGE) {
             // Send dispositions for any messages which were previously delivered and
             // session recovered, but were then not delivered again afterwards.
             Delivery delivery = getEndpoint().head();

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/JmsSessionTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/JmsSessionTest.java
@@ -49,10 +49,6 @@ import org.mockito.Mockito;
  */
 public class JmsSessionTest extends JmsConnectionTestSupport {
 
-    private static final int NO_ACKNOWLEDGE = 257;
-    private static final int ARTEMIS_PRE_ACKNOWLEDGE = 100;
-    private static final int INDIVIDUAL_ACKNOWLEDGE = 101;
-
     @Override
     @BeforeEach
     public void setUp(TestInfo testInfo) throws Exception {
@@ -85,12 +81,12 @@ public class JmsSessionTest extends JmsConnectionTestSupport {
         assertEquals(Session.DUPS_OK_ACKNOWLEDGE, session.getAcknowledgeMode());
         session = (JmsSession) connection.createSession(true, Session.SESSION_TRANSACTED);
         assertEquals(Session.SESSION_TRANSACTED, session.getAcknowledgeMode());
-        session = (JmsSession) connection.createSession(false, NO_ACKNOWLEDGE);
-        assertEquals(NO_ACKNOWLEDGE, session.getAcknowledgeMode());
-        session = (JmsSession) connection.createSession(false, ARTEMIS_PRE_ACKNOWLEDGE);
-        assertEquals(ARTEMIS_PRE_ACKNOWLEDGE, session.getAcknowledgeMode());
-        session = (JmsSession) connection.createSession(false, INDIVIDUAL_ACKNOWLEDGE);
-        assertEquals(INDIVIDUAL_ACKNOWLEDGE, session.getAcknowledgeMode());
+        session = (JmsSession) connection.createSession(false, JmsSession.NO_ACKNOWLEDGE);
+        assertEquals(JmsSession.NO_ACKNOWLEDGE, session.getAcknowledgeMode());
+        session = (JmsSession) connection.createSession(false, JmsSession.ARTEMIS_PRE_ACKNOWLEDGE);
+        assertEquals(JmsSession.ARTEMIS_PRE_ACKNOWLEDGE, session.getAcknowledgeMode());
+        session = (JmsSession) connection.createSession(false, JmsSession.INDIVIDUAL_ACKNOWLEDGE);
+        assertEquals(JmsSession.INDIVIDUAL_ACKNOWLEDGE, session.getAcknowledgeMode());
     }
 
     @Test
@@ -129,7 +125,7 @@ public class JmsSessionTest extends JmsConnectionTestSupport {
     @Test
     @Timeout(10)
     public void testIsNoAcknowledge() throws JMSException {
-        JmsSession session = (JmsSession) connection.createSession(false, NO_ACKNOWLEDGE);
+        JmsSession session = (JmsSession) connection.createSession(false, JmsSession.NO_ACKNOWLEDGE);
         assertFalse(session.isAutoAcknowledge());
         assertFalse(session.isClientAcknowledge());
         assertFalse(session.isDupsOkAcknowledge());
@@ -140,7 +136,7 @@ public class JmsSessionTest extends JmsConnectionTestSupport {
     @Test
     @Timeout(10)
     public void testIsNoAcknowledgeWithArtemisMode() throws JMSException {
-        JmsSession session = (JmsSession) connection.createSession(false, ARTEMIS_PRE_ACKNOWLEDGE);
+        JmsSession session = (JmsSession) connection.createSession(false, JmsSession.ARTEMIS_PRE_ACKNOWLEDGE);
         assertFalse(session.isAutoAcknowledge());
         assertFalse(session.isClientAcknowledge());
         assertFalse(session.isDupsOkAcknowledge());
@@ -160,7 +156,7 @@ public class JmsSessionTest extends JmsConnectionTestSupport {
     @Test
     @Timeout(10)
     public void testIsIndividualAcknowledge() throws JMSException {
-        JmsSession session = (JmsSession) connection.createSession(false, INDIVIDUAL_ACKNOWLEDGE);
+        JmsSession session = (JmsSession) connection.createSession(false, JmsSession.INDIVIDUAL_ACKNOWLEDGE);
         assertFalse(session.isAutoAcknowledge());
         assertFalse(session.isClientAcknowledge());
         assertFalse(session.isDupsOkAcknowledge());

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/integration/AmqpAcknowledgementsIntegrationTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/integration/AmqpAcknowledgementsIntegrationTest.java
@@ -39,6 +39,7 @@ import jakarta.jms.MessageListener;
 import jakarta.jms.Queue;
 import jakarta.jms.Session;
 
+import org.apache.qpid.jms.JmsSession;
 import org.apache.qpid.jms.message.JmsMessageSupport;
 import org.apache.qpid.jms.test.QpidJmsTestCase;
 import org.apache.qpid.jms.test.testpeer.TestAmqpPeer;
@@ -55,7 +56,6 @@ import org.junit.jupiter.api.Timeout;
 
 public class AmqpAcknowledgementsIntegrationTest extends QpidJmsTestCase {
 
-    private static final int INDIVIDUAL_ACK = 101;
     private static final int SKIP = -1;
     private static final int INVALID = 99;
 
@@ -314,7 +314,7 @@ public class AmqpAcknowledgementsIntegrationTest extends QpidJmsTestCase {
 
             testPeer.expectBegin();
 
-            Session session = connection.createSession(INDIVIDUAL_ACK);
+            Session session = connection.createSession(JmsSession.INDIVIDUAL_ACKNOWLEDGE);
             Queue queue = session.createQueue("myQueue");
 
             int msgCount = 6;

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/integration/ConsumerIntegrationTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/integration/ConsumerIntegrationTest.java
@@ -53,6 +53,7 @@ import jakarta.jms.TopicSubscriber;
 import org.apache.qpid.jms.JmsConnection;
 import org.apache.qpid.jms.JmsDefaultConnectionListener;
 import org.apache.qpid.jms.JmsOperationTimedOutException;
+import org.apache.qpid.jms.JmsSession;
 import org.apache.qpid.jms.message.JmsInboundMessageDispatch;
 import org.apache.qpid.jms.policy.JmsDefaultPrefetchPolicy;
 import org.apache.qpid.jms.test.QpidJmsTestCase;
@@ -86,8 +87,6 @@ import org.slf4j.LoggerFactory;
 public class ConsumerIntegrationTest extends QpidJmsTestCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConsumerIntegrationTest.class);
-
-    private static final int INDIVIDUAL_ACKNOWLEDGE = 101;
 
     private final IntegrationTestFixture testFixture = new IntegrationTestFixture();
 
@@ -1228,7 +1227,7 @@ public class ConsumerIntegrationTest extends QpidJmsTestCase {
     @Test
     @Timeout(20)
     public void testMessageListenerClosesItsConsumerAfterRecoverIndividualAck() throws Exception {
-        doMessageListenerClosesItsConsumerTestImpl(true, false, INDIVIDUAL_ACKNOWLEDGE);
+        doMessageListenerClosesItsConsumerTestImpl(true, false, JmsSession.INDIVIDUAL_ACKNOWLEDGE);
     }
 
     @Test
@@ -1252,7 +1251,7 @@ public class ConsumerIntegrationTest extends QpidJmsTestCase {
     @Test
     @Timeout(20)
     public void testMessageListenerClosesItsConsumerBeforeRecoverIndividualAck() throws Exception {
-        doMessageListenerClosesItsConsumerTestImpl(false, true, INDIVIDUAL_ACKNOWLEDGE);
+        doMessageListenerClosesItsConsumerTestImpl(false, true, JmsSession.INDIVIDUAL_ACKNOWLEDGE);
     }
 
     private void doMessageListenerClosesItsConsumerTestImpl(boolean recoverAfterClose, boolean recoverBeforeClose, int ackMode) throws Exception {

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/integration/NoAckSessionIntegrationTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/integration/NoAckSessionIntegrationTest.java
@@ -32,6 +32,7 @@ import jakarta.jms.TemporaryQueue;
 import jakarta.jms.TemporaryTopic;
 import jakarta.jms.Topic;
 
+import org.apache.qpid.jms.JmsSession;
 import org.apache.qpid.jms.test.QpidJmsTestCase;
 import org.apache.qpid.jms.test.testpeer.ListDescribedType;
 import org.apache.qpid.jms.test.testpeer.TestAmqpPeer;
@@ -57,7 +58,7 @@ public class NoAckSessionIntegrationTest extends QpidJmsTestCase {
             Connection connection = testFixture.establishConnecton(testPeer);
             testPeer.expectBegin();
 
-            Session session = connection.createSession(false, 100);
+            Session session = connection.createSession(false, JmsSession.ARTEMIS_PRE_ACKNOWLEDGE);
 
             Destination destination = session.createQueue("MyQueue");
 
@@ -95,31 +96,31 @@ public class NoAckSessionIntegrationTest extends QpidJmsTestCase {
     @Test
     @Timeout(20)
     public void testNoAckSessionAppliedToTopic() throws Exception {
-        doTestConsumerWithPresettleOptions(100, Topic.class);
+        doTestConsumerWithPresettleOptions(JmsSession.ARTEMIS_PRE_ACKNOWLEDGE, Topic.class);
     }
 
     @Test
     @Timeout(20)
     public void testNoAckSessionAppliedToTopicAltMode() throws Exception {
-        doTestConsumerWithPresettleOptions(257, Topic.class);
+        doTestConsumerWithPresettleOptions(JmsSession.NO_ACKNOWLEDGE, Topic.class);
     }
 
     @Test
     @Timeout(20)
     public void testNoAckSessionAppliedToQueue() throws Exception {
-        doTestConsumerWithPresettleOptions(100, Queue.class);
+        doTestConsumerWithPresettleOptions(JmsSession.ARTEMIS_PRE_ACKNOWLEDGE, Queue.class);
     }
 
     @Test
     @Timeout(20)
     public void testNoAckSessionAppliedToTempTopic() throws Exception {
-        doTestConsumerWithPresettleOptions(100, TemporaryTopic.class);
+        doTestConsumerWithPresettleOptions(JmsSession.ARTEMIS_PRE_ACKNOWLEDGE, TemporaryTopic.class);
     }
 
     @Test
     @Timeout(20)
     public void testNoAckSessionAppliedToTempQueue() throws Exception {
-        doTestConsumerWithPresettleOptions(100, TemporaryQueue.class);
+        doTestConsumerWithPresettleOptions(JmsSession.ARTEMIS_PRE_ACKNOWLEDGE, TemporaryQueue.class);
     }
 
     //----- Test Method implementation ---------------------------------------//

--- a/qpid-jms-client/src/test/java/org/apache/qpid/jms/integration/SessionIntegrationTest.java
+++ b/qpid-jms-client/src/test/java/org/apache/qpid/jms/integration/SessionIntegrationTest.java
@@ -105,8 +105,6 @@ public class SessionIntegrationTest extends QpidJmsTestCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(SessionIntegrationTest.class);
 
-    private static final int INDIVIDUAL_ACK = 101;
-
     private final IntegrationTestFixture testFixture = new IntegrationTestFixture();
 
     @Test
@@ -2281,7 +2279,7 @@ public class SessionIntegrationTest extends QpidJmsTestCase {
 
             testPeer.expectBegin();
 
-            Session session = connection.createSession(INDIVIDUAL_ACK);
+            Session session = connection.createSession(JmsSession.INDIVIDUAL_ACKNOWLEDGE);
             Queue queue = session.createQueue("myQueue");
 
             int msgCount = 5;


### PR DESCRIPTION
In order to make existing constants for custom acknowledge modes in `JmsSession` reusable in similar fashion to those from `jakarta.jms.Session`, this commit changes their visibility from `private` to `public`.